### PR TITLE
Add a way to specify the uid for jmeter user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,23 @@
+# Dockerizing JMETER
+#
+# build : docker build -t exoplatform/jmeter .
+#
 FROM    exoplatform/base-jdk:jdk8
 LABEL   maintainer="eXo Platform <docker@exoplatform.com>"
 
 ARG JMETER_VERSION=3.3
 
-# RUN apt-get update && apt-get install
-RUN groupadd --gid 1000 jmeter && useradd --gid 1000 --uid 1000 -d /usr/local/jmeter jmeter
+# Install GOSU
+RUN gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4
+RUN curl -o /usr/local/bin/gosu -SL "https://github.com/tianon/gosu/releases/download/1.10/gosu-$(dpkg --print-architecture)" \
+    && curl -o /usr/local/bin/gosu.asc -SL "https://github.com/tianon/gosu/releases/download/1.10/gosu-$(dpkg --print-architecture).asc" \
+    && gpg --verify /usr/local/bin/gosu.asc \
+    && rm /usr/local/bin/gosu.asc \
+    && chmod +x /usr/local/bin/gosu
 
+# Install JMETER
 RUN cd /usr/local && wget -O jmeter.tgz https://archive.apache.org/dist/jmeter/binaries/apache-jmeter-${JMETER_VERSION}.tgz && tar xzf jmeter.tgz \
-    && ln -s apache-jmeter-${JMETER_VERSION} jmeter && rm jmeter.tgz \
-    && chown -R jmeter:jmeter apache-jmeter-${JMETER_VERSION}
+    && ln -s apache-jmeter-${JMETER_VERSION} jmeter && rm jmeter.tgz
 
 RUN cd /usr/local/jmeter/lib/ext && wget -O plugins-manager.jar https://jmeter-plugins.org/get/
 
@@ -22,16 +31,17 @@ RUN cd /usr/local/jmeter && wget -O plugin.zip https://jmeter-plugins.org/files/
 COPY entrypoint.sh /
 RUN chmod 755 /entrypoint.sh
 
+RUN mkdir -p /scripts && chmod 755 /scripts \
+    && mkdir -p /output && chmod 777 /output
+
+WORKDIR /output
+
 ####
 ## Configuration
 RUN echo "# This switch is needed for some JMeter Plugins reports" >> /usr/local/jmeter/bin/user.properties \
     && echo "jmeter.save.saveservice.thread_counts=true" >> /usr/local/jmeter/bin/user.properties
 
 ENV JVM_ARGS="-Duser.language=en -Duser.region=EN"
-
-USER jmeter
-
-WORKDIR /usr/local/jmeter
 
 ENV JMETER_PROPERTY_PREFIX=JMETERPROP_
 

--- a/README.md
+++ b/README.md
@@ -2,8 +2,29 @@
 
 ## Usage
 
+Important directories :
+* ``/scripts/`` for the jmeter scripts and csv datasources
+* ``/output/`` for all jmeter generated data (log file, csv/jtl files, reports, ...)
+
 ```
-docker run -ti --rm -v /path/to/my/scripts:/scripts -v /path/to/results:/output -e HEAP="-e HEAP="-Xms512m -Xmx512m" exoplatform/jmeter:latest -t /scripts/myscript.jmx -o /output/result``
+docker run -ti --rm -v /path/to/my/scripts:/scripts:ro -v /path/to/results:/output:rw \
+    exoplatform/jmeter:latest -n -t /scripts/myscript.jmx -o /output/result
+```
+
+### Usage for benchmark
+
+```
+docker run -ti --rm -v /path/to/my/scripts:/scripts:ro -v /path/to/results:/output:rw \
+    exoplatform/jmeter:latest -n -t /scripts/myscript.jmx -o /output/result/
+```
+
+WARNING: don't forget to pass the ``-n`` parameter to run jmeter in no gui mode
+
+### Usage for report generation
+
+```
+docker run -ti --rm -v /path/to/results:/output:rw \
+    exoplatform/jmeter:latest -g /output/bench/benchmark.csv -o /output/report/
 ```
 
 ## Bench properties
@@ -12,3 +33,24 @@ Any property prefixed with ``JMETERPROP_`` will be passed to the jmeter script o
 
 For example, if you add the parameter ``-e JMETERPROP_param1=value1`` to the docker command line, the option ``-Jparam1=value1`` will be added to the jmeter command line
 
+## Configuration
+
+### JVM Heap
+
+You can configure JMeter's JVM Heap with the ``HEAP`` environment variable :
+
+```
+docker run -ti --rm -e HEAP="-Xms512m -Xmx512m" exoplatform/jmeter:latest
+```
+
+### User UID inside the container
+
+To avoid file permission problems when writting files in mounted directory from the host (ex: ``/output/``), you can specify the user UID to use to launch jmeter inside the container with the variable ``LOCAL_USER_ID``.
+
+ex: laucnh JMeter with the same UID than the current user launching the container on the host :
+
+```
+docker run -ti --rm -e LOCAL_USER_ID=`id -u $USER` \
+    -v /path/to/my/scripts:/scripts -v /path/to/results:/output \
+    exoplatform/jmeter:latest -n -t /scripts/myscript.jmx -o /output/result
+```

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,16 +1,30 @@
 #!/bin/bash -eu
 
-# WARNING Not supporting spaces
-PROPERTIES=$(env | grep "^${JMETER_PROPERTY_PREFIX:-NOT_EXISTS}" || true)
+# Add local user
+# Either use the LOCAL_USER_ID if passed in at runtime or fallback
+USER_ID=${LOCAL_USER_ID:-1000}
+USER_NAME=${LOCAL_USER_NAME:-jmeter}
+echo "Starting with UID=$USER_ID($USER_NAME)"
+useradd --shell /bin/bash -u $USER_ID -o -c "" -m $USER_NAME
 
-PROPERTIES_STRING=""
-for i in ${PROPERTIES}
-do
-    PROPERTIES_STRING="${PROPERTIES_STRING} -J$(echo ${i} | sed s/${JMETER_PROPERTY_PREFIX}//g)"
-done
+# allow starting the container with bash (for Docker image debuging purpose)
+if [[ ${@:-nothing} == bash* ]]; then
+    shift # we remove bash from the arguments
+    [ ! -z "$@" ] && echo "Starting bash but ignoring other parameters ($@)"
+    bash
+else
+    # WARNING Not supporting spaces
+    PROPERTIES=$(env | grep "^${JMETER_PROPERTY_PREFIX:-NOT_EXISTS}" || true)
 
-if [ ! -z "${PROPERTIES_STRING}" ]; then
-    echo Executing with additional properties : ${PROPERTIES_STRING}
+    PROPERTIES_STRING=""
+    for i in ${PROPERTIES}
+    do
+        PROPERTIES_STRING="${PROPERTIES_STRING} -J$(echo ${i} | sed s/${JMETER_PROPERTY_PREFIX}//g)"
+    done
+
+    if [ ! -z "${PROPERTIES_STRING}" ]; then
+        echo Executing with additional properties : ${PROPERTIES_STRING}
+    fi
+
+    exec /usr/local/bin/gosu $USER_NAME /usr/local/jmeter/bin/jmeter ${PROPERTIES_STRING} "$@"
 fi
-
-/usr/local/jmeter/bin/jmeter -n ${PROPERTIES_STRING} "$@"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -eu
 
 # WARNING Not supporting spaces
-PROPERTIES=$(env | grep "^${JMETER_PROPERTY_PREFIX}")
+PROPERTIES=$(env | grep "^${JMETER_PROPERTY_PREFIX:-NOT_EXISTS}" || true)
 
 PROPERTIES_STRING=""
 for i in ${PROPERTIES}


### PR DESCRIPTION
- create the user before starting jmeter
- use gosu to switch from root to the specified user
- ability to specify the user UID with LOCAL_USER_ID (default: 1000)
- ability to specify the user username with LOCAL_USER_NAME (default: jmeter)
- improve the doc
- add a way to start bash instead of jmeter for image debuging purpose